### PR TITLE
Add link to top companies responsible for emissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Sustainable-Earth is an amazing list for people who want to live more sustainabl
 # Articles
 
 * 2017-08-07 - [Fossil fuel subsidies are a staggering $5 tn per year](https://www.theguardian.com/environment/climate-consensus-97-per-cent/2017/aug/07/fossil-fuel-subsidies-are-a-staggering-5-tn-per-year).
+* 2017-07-10 - [Just 100 companies responsible for 71% of global emissions, study says](https://www.theguardian.com/sustainable-business/2017/jul/10/100-fossil-fuel-companies-investors-responsible-71-global-emissions-cdp-study-climate-change).
 * 2017-03-23 - [Scientists made a detailed “roadmap” for meeting the Paris climate goals. It’s eye-opening.](https://www.vox.com/energy-and-environment/2017/3/23/15028480/roadmap-paris-climate-goals)
 
 # Movies


### PR DESCRIPTION
Add link to top companies responsible for emissions.

## Link URL
https://www.theguardian.com/sustainable-business/2017/jul/10/100-fossil-fuel-companies-investors-responsible-71-global-emissions-cdp-study-climate-change

## Description
Add link to top companies responsible for emissions.
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one item/change is in this pull request
- [x] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x] It's in English
