### PR TITLE
Whitelist duped links to SustainForEarth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - gem install awesome_bot
   - gem install danger
 script:
-  - allowed_dupes=CONTRIBUTING
+  - allowed_dupes=CONTRIBUTING,SustainForEarth
   - awesome_bot README.md --allow-ssl --white-list $allowed_dupes
   - danger
 notifications:


### PR DESCRIPTION
Whitelist duped links to SustainForEarth

## Link URL
https://twitter.com/SustainForEarth

## Description
Whitelist duped links to SustainForEarth
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
N/A
