### PR TITLE
Add Twitter shields badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://api.travis-ci.org/bizz84/Sustainable-Earth.svg?branch=master)](https://travis-ci.org/bizz84/Sustainable-Earth)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-
+[![Twitter](https://img.shields.io/badge/twitter-@SustainForEarth-blue.svg?maxAge=2592000)](https://twitter.com/SustainForEarth)
 
 # About
 


### PR DESCRIPTION
Add Twitter shields badge.

## Link URL
https://twitter.com/SustainForEarth

## Description
Add Twitter shields badge.
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
N/A
