### PR TITLE
Fix format on description of Six Degrees link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sustainable-Earth is an amazing list for people who want to live more sustainabl
 # Books
 * [Leftover Pie](https://leftoverpie.co.uk/) - 101 ways to reduce your food waste.
 * [Drawdown](http://www.drawdown.org/) - The most comprehensive plan ever proposed to reverse global warming.
-* [Six Degrees](https://www.amazon.com/Six-Degrees-Future-Hotter-Planet/dp/0007209053): Our future on a hotter planet 
+* [Six Degrees](https://www.amazon.com/Six-Degrees-Future-Hotter-Planet/dp/0007209053): Our future on a hotter planet.
 
 # Climate Protection Projects
 * [Trump Forest](https://trumpforest.com/) - Where ignorance grows trees.


### PR DESCRIPTION
Fix format on description of Six Degrees link

## Link URL
https://www.amazon.com/Six-Degrees-Future-Hotter-Planet/dp/0007209053

## Description
Fix format on description of Six Degrees link
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one item/change is in this pull request
- [x] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x] It's in English
