### PR TITLE
Remove Greenpeace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Sustainable-Earth is an amazing list for people who want to live more sustainabl
 
 # Companies
 * [Give Directly](https://www.givedirectly.org/) - Send money directly to people living in extreme poverty.
-* [Greenpeace](http://www.greenpeace.org/international/en/) - Independent organisation to protect and conserve the environment and promote peace.
 * [350.org](https://350.org/) - building the global grassroots climate movement that can hold our leaders accountable to science and justice.
 
 # Apps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link URL
http://www.greenpeace.org/international/en/
 
## Why it should be removed from `Sustainable-Earth` (optional)
Trying to reduce links to organizations that may be too political.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one item/change is in this pull request
- [x] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x] It's in English
