### PR TITLE
Remove 350.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Sustainable-Earth is an amazing list for people who want to live more sustainabl
 
 # Companies
 * [Give Directly](https://www.givedirectly.org/) - Send money directly to people living in extreme poverty.
-* [350.org](https://350.org/) - building the global grassroots climate movement that can hold our leaders accountable to science and justice.
 
 # Apps
 * [Eco Buddy](http://ecobuddyapp.com/) - A diary of your carbon footprint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link URL
https://350.org/

## Description
Building the global grassroots climate movement that can hold our leaders accountable to science and justice.
May be too political for inclusion here.
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one item/change is in this pull request
- [x] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x] It's in English
