### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The author believes that **protecting the environment is an urgent matter** and 
 
 # Movies
 * [Before The Flood](https://www.beforetheflood.com/) - documentary about Climate Change, featuring Leonardo DiCaprio.
+* [An Inconvenient Truth](https://en.wikipedia.org/wiki/An_Inconvenient_Truth) - 2006 documentary about Climate Change made by Al Gore
 
 # YouTube
 * [Paul Beckwith](https://www.youtube.com/channel/UCr546o7ImhGM57qoY0hHvkA) - videos about abrupt climate change ([Paul Beckwith bio](https://paulbeckwith.net/about/))


### PR DESCRIPTION
Add a link to the 2006 documentary by Al Gore: "An Inconvenient Truth"

## Link URL
https://en.wikipedia.org/wiki/An_Inconvenient_Truth

## Description
Wikipedia page about the documentary by Al Gore

It would be better to link the movie, but for some reason it's not available online.
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one item/change is in this pull request
- [x] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x] It's in English
