### PR TITLE
Add link to ecological Armageddon article

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The author believes that **protecting the environment is an urgent matter** and 
 
 # Articles
 
+* 2017-10-18 - [Warning of 'ecological Armageddon' after dramatic plunge in insect numbers](https://www.theguardian.com/environment/2017/oct/18/warning-of-ecological-armageddon-after-dramatic-plunge-in-insect-numbers)
 * 2017-09-14 - [100 Percent Wishful Thinking: the Green-Energy Cornucopia](https://www.counterpunch.org/2017/09/14/100-percent-wishful-thinking-the-green-energy-cornucopia/)
 * 2017-09-07 - [In a summer of wildfires and hurricanes, my son asks "why is everything going wrong?"](https://theintercept.com/2017/09/09/in-a-summer-of-wildfires-and-hurricanes-my-son-asks-why-is-everything-going-wrong/)
 * 2017-08-29 - [More Than 1,000 Died in South Asia Floods This Summer.](https://www.nytimes.com/2017/08/29/world/asia/floods-south-asia-india-bangladesh-nepal-houston.html)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link URL
<!--- The link URL -->
https://www.theguardian.com/environment/2017/oct/18/warning-of-ecological-armageddon-after-dramatic-plunge-in-insect-numbers

## Description
<!--- Describe your changes in detail -->
Add link to "Warning of 'ecological Armageddon' after dramatic plunge in insect numbers"
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one item/change is in this pull request
- [x] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x] It's in English