### PR TITLE
Add a new tool. (estimated value of the CO2-emission of your website)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The purpose of this project is as follows:
 
 #### Inform and empower people to make choices leading to a better future for humankind.
 
-**NOTE**: Some of the content on this list is of political nature (see [this thread](https://news.ycombinator.com/item?id=15148860) on Hacker News). 
+**NOTE**: Some of the content on this list is of political nature (see [this thread](https://news.ycombinator.com/item?id=15148860) on Hacker News).
 
 The author believes that **protecting the environment is an urgent matter** and more important than trying to keep politics out of the equation.
 
@@ -94,6 +94,7 @@ The author believes that **protecting the environment is an urgent matter** and 
 * [Climate Reanalyzer](http://www.cci-reanalyzer.org/) - A platform for visualizing climate and weather datasets.
 * [Climate Life Events](https://climate-life-events.herokuapp.com/) - Climate change and life events estimation tool.
 * [Danish Metereological Institute - Artic Temperatures](http://ocean.dmi.dk/arctic/meant80n.uk.php) - Daily mean temperatures north of 80 degree north.
+* [WebsiteCarbon](https://www.websitecarbon.com/) - Get an estimated value of CO2-emission of your website.
 
 # Articles
 


### PR DESCRIPTION
Add a new tool. (estimated value of the CO2-emission of your website)

## Link URL
https://www.websitecarbon.com/

## Description
I add a link to a great project that tries to estimate the carbon emissions of websites. The result shows how much CO2 your website is producing and so it might help you to take action and try to reduce the emission of your website.
 
## Why it should be included to `Sustainable-Earth` (optional)
I think it is necessary to take action on web-development site. The internet is producing as much as CO2 as traveling and the number is growing.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] Only one item/change is in this pull request
- [x ] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [ x] It's in English
