### PR TITLE
Add link to TooGoodToGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The author believes that **protecting the environment is an urgent matter** and 
 * [ShareTheMeal](https://sharethemeal.org/) - Together we can end hunger.
 * [Plume Labs](https://plumelabs.com/en/) - The first smart air quality tracker.
 * [farmdrop](https://www.farmdrop.com/) - The ethical grocer. Currently available in London, Bristol & Bath (UK).
+* [TooGoodToGo](https://toogoodtogo.com/en) - Fight the waste of food. 
 
 # Blogs / Publications
 * [Faster Than Expected](http://www.fasterthanexpected.com/blog/) - Diary about a world that is changing faster than expected, as reported by various sources.


### PR DESCRIPTION
Add link to TooGoodToGo

## Link URL
https://toogoodtogo.com/en

## Description
Adding app TooGoodToGo in readme.md
 
## Why it should be included to `Sustainable-Earth` (optional)

## Checklist
- [x ] Only one item/change is in this pull request
- [x ] Addition in chronological order (bottom of category) or sorted by most recent date (for articles)
- [x ] It's in English
